### PR TITLE
Fixed [Bug] #67: 'Sign Up' Button Overlaps with Border on Login Page 

### DIFF
--- a/src/css/login.css
+++ b/src/css/login.css
@@ -239,7 +239,9 @@ input[type="password"]:focus {
 p {
     font-size: 14px;
     color: #555;
-    margin-top: 15px;
+    margin-top: 20px;
+    margin-bottom: 30px;
+    text-align: center;
 }
 
 a {


### PR DESCRIPTION
Related Issues: #67 
This PR resolves a UI bug where the 'Sign Up' button was overlapping with the border on the login page. The issue was caused by improper alignment of elements in the layout. The following changes were made to fix the bug:

Adjusted the margin and padding of the button to prevent overlap.
Updated CSS to ensure consistent spacing between elements on different screen sizes.
Tested the fix on various devices to ensure responsiveness and proper alignment.
After fix:
![Screenshot (110)](https://github.com/user-attachments/assets/ad596c30-6445-40b5-9afd-267c7bf9bfaf)




