### PR TITLE
Home page link edit

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@
       <nav class="menu">
         <ul>
           <li>
-            <a href="/" id="home-link" onclick="changeContent('home')"><i class="fa-solid fa-house"></i> Home</a>
+            <a href="./index.html" id="home-link" onclick="changeContent('home')"><i class="fa-solid fa-house"></i> Home</a>
           </li>
           <li>
             <a href="features.html" id="features-link" onclick="changeContent('features')"><i


### PR DESCRIPTION
Fixes #437 When we click on home page on navbar it show 404 page error because their path is mapped to "/" instead of "./index.html" now i'm edit the path in correct way and also test the again functionality!

![beforeEditing](https://github.com/user-attachments/assets/f2802560-7057-4935-ab56-98aafe2fb609)

@mansiruhil13 Please review my PR and merge accordingly with the labels:)