### PR TITLE
FIXES ISSUE ##464: [Bug]: Scroll up button fixed at the bottom of the screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,6 +699,11 @@
         padding: 10px 15px;
         font-size: 16px;
         cursor: pointer;
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        z-index: 99;
+
       ">↑</button>
     </div>
   </footer>


### PR DESCRIPTION
This PR Fixes Issue #464 


Previously the scroll up button was fixated at the bottom of the page but now it is made floating at the bottom right corner of the screen.
Before
![image](https://github.com/user-attachments/assets/15c869e7-6ad0-43a9-b3ba-c67733230489)
![image](https://github.com/user-attachments/assets/6ae62017-d7a5-4264-8650-c47d7262ab64)
After
![image](https://github.com/user-attachments/assets/28ca2e79-1545-446c-9378-9e0b8c6432d0)
![image](https://github.com/user-attachments/assets/59e2e274-3179-4705-9ef4-703006451e12)

don't forget to label it as GSSOC extd, hacktoberfest accepted with level1/2/3 accordingly.
Thank You!