### PR TITLE
Enforce Push to Newly Created Branches, Not Main Branch 

### DIFF
--- a/.github/workflows/PR_message.yml
+++ b/.github/workflows/PR_message.yml
@@ -16,7 +16,7 @@ jobs:
             curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-              -d '{"body": "### :warning: Warning: Please create a new branch!\n\nIt looks like your pull request is based on the `main` or `master` branch. To keep the repository organized and avoid conflicts, please follow these steps:\n\n1. Close this PR.\n2. Create a new branch using `git checkout -b your-branch-name`.\n3. Make your changes in that branch and open a new PR.\n\nThank you!"}'
+              -d '{"body": "### :warning: Warning: Create a new branch!\n\nIt looks like this pull request is from the `main` or `master` branch, which is not allowed.. To keep the repository organized and avoid conflicts, you have to create a new branch. So please follow these steps:\n\n1. Close this PR.\n2. Create a new branch using `git checkout -b your-branch-name`.\n3. Make your changes in that branch and open a new PR.\n\nThank you!"}'
             exit 1
           fi
 
@@ -26,4 +26,4 @@ jobs:
           curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            -d '{"body": "### Thank you for opening a Pull Request!\n\nYour contribution is highly appreciated. Please make sure your PR meets the following guidelines:\n\n1. Follow our [contribution guidelines](https://link-to-guidelines).\n2. Ensure all code is properly documented.\n3. Add tests for your new code if applicable.\n\nThank you for your contribution!"}'
+            -d '{"body": "### Thank you for opening a Pull Request!\n\nYour contribution is highly appreciated. Please make sure your PR meets the following guidelines:\n\n1. Follow our [contribution guidelines](https://link-to-guidelines).\n2. Ensure all code is properly documented.\n3. Add tests for your new code if applicable.\n4. Make sure you mention the issue # for which you were assigned.\n\nThank you for your contribution!"}'

--- a/.github/workflows/PR_message.yml
+++ b/.github/workflows/PR_message.yml
@@ -1,0 +1,29 @@
+name: PR Validation and Comment Bot
+
+# Trigger the workflow on pull request creation
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if PR is from main or master
+        run: |
+          if [[ "${{ github.event.pull_request.head.ref }}" == "main" || "${{ github.event.pull_request.head.ref }}" == "master" ]]; then
+            curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              -d '{"body": "### :warning: Warning: Please create a new branch!\n\nIt looks like your pull request is based on the `main` or `master` branch. To keep the repository organized and avoid conflicts, please follow these steps:\n\n1. Close this PR.\n2. Create a new branch using `git checkout -b your-branch-name`.\n3. Make your changes in that branch and open a new PR.\n\nThank you!"}'
+            exit 1
+          fi
+
+      - name: Comment on valid PR
+        if: ${{ success() }}
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            -d '{"body": "### Thank you for opening a Pull Request!\n\nYour contribution is highly appreciated. Please make sure your PR meets the following guidelines:\n\n1. Follow our [contribution guidelines](https://link-to-guidelines).\n2. Ensure all code is properly documented.\n3. Add tests for your new code if applicable.\n\nThank you for your contribution!"}'

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,18 @@
+name: Instructions Bot 
+
+# Trigger the workflow on issue assignment
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  add_pr_instructions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add a comment with PR instructions
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            -d '{"body": "### Instructions for Creating a Pull Request:\n\n1. Fork the repository if you haven\'t already.\n2. Create a new branch for your work: `git checkout -b feature-branch-name`.\n3. Make your changes in this branch.\n4. Commit your changes with a clear message: `git commit -m \"Describe your changes\"`.\n5. Push your branch to your forked repository: `git push origin feature-branch-name`.\n6. Go to the original repository and click on **New Pull Request**.\n7. Select your branch and submit the PR for review.\n8. Link the PR to this issue by adding the keyword **Closes #issue_number** in the PR description.\n\nThank you!"}'


### PR DESCRIPTION
#325 Resolved

This ensures that the contributor requests a PR from the new branch not the main or master branch.
