### PR TITLE
 Some Changes in privacy.html file

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -94,6 +94,7 @@
         background: #10141b;
         border-radius: 15px;
         box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+        margin-bottom: 25px;
       }
       h2 {
         color: #1e88e5;


### PR DESCRIPTION

#### Problem
The privacy page was directly touching the footer section, causing a lack of space between the two elements. This resulted in a crowded layout and poor readability.

#### Solution
To resolve the issue, I have added a bottom margin to the privacy page, ensuring there is sufficient space between the page content and the footer. This improves the visual structure and enhances readability.

#### Changes Made
- Added CSS margin to the bottom of the privacy page.
- Verified the changes to ensure proper spacing across different screen sizes.

![image](https://github.com/user-attachments/assets/16736184-e56f-49c6-a333-2cda5e93236d)


#### Status
-  Everything is up-to-date and functioning as expected.

This PR resolves the issue and maintains a consistent, user-friendly layout.